### PR TITLE
bugfix ZookeeperShardState:IOException is never thrown

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/state/zookeeper/ZookeeperShardState.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/state/zookeeper/ZookeeperShardState.java
@@ -61,13 +61,14 @@ class ZookeeperShardState {
         this.config = config;
         this.rand = new Random();
 
-        try {
+/* bugfix:exception IOException is never thrown in body of corresponding try statement */
+//        try {
             zk = CuratorFrameworkFactory.newClient(config.getZookeeperConnectionString(),
                     new ExponentialBackoffRetry(BASE_SLEEP_TIME_MS, MAX_NUM_RETRIES));
-        } catch (IOException e) {
-            LOG.error("Could not connect to ZooKeeper", e);
-            throw new KinesisSpoutException(e);
-        }
+//        } catch (IOException e) {
+//            LOG.error("Could not connect to ZooKeeper", e);
+//            throw new KinesisSpoutException(e);
+//        }
         zk.start();
     }
 


### PR DESCRIPTION
ZookeeperSharedState can't be compiled because it has unnecessary try-catch clause.

```
[info] Compiling 28 Java sources to /home/vagrant/kinesis-storm-spout/target/scala-2.10/classes...
[error] /home/vagrant/kinesis-storm-spout/src/main/java/com/amazonaws/services/kinesis/stormspout/state/zookeeper/ZookeeperShardState.java:67: error: exception IOException is never thrown in body of corresponding try statement
[error]         } catch (IOException e) {
[error]           ^
[error] 1 error
[error] (compile:compile) javac returned nonzero exit code
```
