### PR TITLE
Pass shardId to IKinesisRecordScheme#deserialize

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/DefaultKinesisRecordScheme.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/DefaultKinesisRecordScheme.java
@@ -32,6 +32,10 @@ public class DefaultKinesisRecordScheme implements IKinesisRecordScheme {
      */
     public static final String FIELD_PARTITION_KEY = "partitionKey";
     /**
+     * Name of the (shard id) value in the tuple.
+     */
+    public static final String FIELD_SHARD_ID = "shardId";
+    /**
      * Name of the (Kinesis record) value in the tuple.
      */
     public static final String FIELD_RECORD = "record";
@@ -50,9 +54,10 @@ public class DefaultKinesisRecordScheme implements IKinesisRecordScheme {
      * .Record)
      */
     @Override
-    public List<Object> deserialize(Record record) {
+    public List<Object> deserialize(Record record, String shardId) {
         final List<Object> l = new ArrayList<>();
         l.add(record.getPartitionKey());
+        l.add(shardId);
         l.add(record);
         return l;
     }
@@ -64,6 +69,6 @@ public class DefaultKinesisRecordScheme implements IKinesisRecordScheme {
      */
     @Override
     public Fields getOutputFields() {
-        return new Fields(FIELD_PARTITION_KEY, FIELD_RECORD);
+        return new Fields(FIELD_PARTITION_KEY, FIELD_SHARD_ID, FIELD_RECORD);
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/IKinesisRecordScheme.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/IKinesisRecordScheme.java
@@ -30,7 +30,7 @@ public interface IKinesisRecordScheme extends java.io.Serializable {
      * @param record Kinesis record
      * @return List of values (to be emitted as a tuple)
      */
-    List<Object> deserialize(Record record);
+    List<Object> deserialize(Record record, String shardId);
 
     /**
      * @return output fields

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
@@ -180,7 +180,7 @@ public class KinesisSpout implements IRichSpout, Serializable {
             if (rec != null) {
                 // Copy record (ByteBuffer.duplicate()) so bolts in the same JVM don't affect the object (e.g. retries)
                 Record recordToEmit = copyRecord(rec);
-                List<Object> tuple = config.getScheme().deserialize(recordToEmit);
+                List<Object> tuple = config.getScheme().deserialize(recordToEmit, currentShardId);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(this + " emitting record with seqnum " + recordToEmit.getSequenceNumber() + " from shard "
                             + currentShardId + ".");

--- a/src/main/samples/SampleKinesisRecordScheme.java
+++ b/src/main/samples/SampleKinesisRecordScheme.java
@@ -30,6 +30,11 @@ public class SampleKinesisRecordScheme implements IKinesisRecordScheme {
      * Name of the (partition key) value in the tuple.
      */
     public static final String FIELD_PARTITION_KEY = "partitionKey";
+
+    /**
+     * Name of the (shard id) value in the tuple.
+     */
+    public static final String FIELD_SHARD_ID = "shardId";
     
     /**
      * Name of the sequence number value in the tuple.
@@ -55,9 +60,10 @@ public class SampleKinesisRecordScheme implements IKinesisRecordScheme {
      * .Record)
      */
     @Override
-    public List<Object> deserialize(Record record) {
+    public List<Object> deserialize(Record record, String shardId) {
         final List<Object> l = new ArrayList<>();
         l.add(record.getPartitionKey());
+        l.add(shardId);
         l.add(record.getSequenceNumber());
         l.add(record.getData().array());
         return l;
@@ -70,6 +76,6 @@ public class SampleKinesisRecordScheme implements IKinesisRecordScheme {
      */
     @Override
     public Fields getOutputFields() {
-        return new Fields(FIELD_PARTITION_KEY, FIELD_SEQUENCE_NUMBER, FIELD_RECORD_DATA);
+        return new Fields(FIELD_PARTITION_KEY, FIELD_SHARD_ID, FIELD_SEQUENCE_NUMBER, FIELD_RECORD_DATA);
     }
 }


### PR DESCRIPTION
I wanted to have access to the records' shardId in my storm topologies and I couldn't find any other way to do it.  So, here's my patch just in case it's useful to anybody.
