### PR TITLE
Add millis behind latest and retry count metrics in KinesisSpout, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 AwsCredentials.properties
+.idea
+**.iml

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
+            <artifactId>aws-java-sdk-kinesis</artifactId>
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <aws-java-sdk.version>1.10.29</aws-java-sdk.version>
         <storm.version>0.9.5</storm.version>
         <curator-framework.version>1.1.3</curator-framework.version>
-        <guava.version>13.0-final</guava.version>
+        <guava.version>18.0</guava.version>
         <commons-lang3.version>3.0</commons-lang3.version>
     </properties>
     
@@ -47,12 +47,12 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.storm</groupId>
             <artifactId>storm-core</artifactId>
             <version>${storm.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.netflix.curator</groupId>
@@ -103,6 +103,31 @@
             </execution>
           </executions>
         </plugin>
+          <plugin>
+              <!-- Embed guava to avoid clashing with guava version imported in storm -->
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>jarjar-maven-plugin</artifactId>
+              <version>1.9</version>
+              <executions>
+                  <execution>
+                      <phase>package</phase>
+                      <goals>
+                          <goal>jarjar</goal>
+                      </goals>
+                      <configuration>
+                          <includes>
+                              <include>com.google.guava:guava</include>
+                          </includes>
+                          <rules>
+                              <rule>
+                                  <pattern>com.google.**</pattern>
+                                  <result>com.amazonaws.services.kinesis.stormspout.@1</result>
+                              </rule>
+                          </rules>
+                      </configuration>
+                  </execution>
+              </executions>
+          </plugin>
       </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 
     <properties>
-        <aws-java-sdk.version>1.10.4</aws-java-sdk.version>
+        <aws-java-sdk.version>1.10.29</aws-java-sdk.version>
         <storm.version>0.9.5</storm.version>
         <curator-framework.version>1.1.3</curator-framework.version>
         <guava.version>13.0-final</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>kinesis-storm-spout</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Storm Spout for Java</name>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <description> The Amazon Kinesis Storm Spout helps Java developers integrate Amazon Kinesis with Storm.</description>
     <url>https://aws.amazon.com/kinesis</url>
 
@@ -24,8 +24,8 @@
 
 
     <properties>
-        <aws-java-sdk.version>1.7.13</aws-java-sdk.version>
-        <storm.version>0.9.2-incubating</storm.version>
+        <aws-java-sdk.version>1.10.4</aws-java-sdk.version>
+        <storm.version>0.9.5</storm.version>
         <curator-framework.version>1.1.3</curator-framework.version>
         <guava.version>13.0-final</guava.version>
         <commons-lang3.version>3.0</commons-lang3.version>

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/BufferedGetter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/BufferedGetter.java
@@ -40,7 +40,7 @@ class BufferedGetter implements IShardGetter {
 
     /**
      * Creates a (shard) getter that buffers records.
-     * 
+     *
      * @param underlyingGetter Unbuffered shard getter.
      * @param maxBufferSize Max number of records to fetch from the underlying getter.
      * @param emptyRecordListBackoffMillis Backoff time between GetRecords calls if previous call fetched no records.
@@ -48,10 +48,10 @@ class BufferedGetter implements IShardGetter {
     public BufferedGetter(final IShardGetter underlyingGetter, final int maxBufferSize, final long emptyRecordListBackoffMillis) {
         this(underlyingGetter, maxBufferSize, emptyRecordListBackoffMillis, new TimeProvider());
     }
-    
+
     /**
      * Used for unit testing.
-     * 
+     *
      * @param underlyingGetter Unbuffered shard getter
      * @param maxBufferSize Max number of records to fetch from the underlying getter
      * @param emptyRecordListBackoffMillis Backoff time between GetRecords calls if previous call fetched no records.
@@ -72,7 +72,7 @@ class BufferedGetter implements IShardGetter {
         ensureBuffered();
 
         if (!it.hasNext() && buffer.isEndOfShard()) {
-            return new Records(ImmutableList.<Record> of(), true);
+            return new Records(ImmutableList.<Record> of(), -1l, true);
         }
 
         ImmutableList.Builder<Record> recs = new ImmutableList.Builder<>();
@@ -94,7 +94,7 @@ class BufferedGetter implements IShardGetter {
             }
         }
 
-        return new Records(recs.build(), false);
+        return new Records(recs.build(),buffer.getMillisBehindLatest(), false);
     }
 
     @Override
@@ -132,8 +132,8 @@ class BufferedGetter implements IShardGetter {
             }
         }
     }
-    
-    /** 
+
+    /**
      * Time provider - helpful for unit tests of BufferedGetter.
      */
     static class TimeProvider {

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.io.Serializable;
 import java.util.List;
@@ -46,6 +47,7 @@ import java.util.Map;
 public class KinesisSpout implements IRichSpout, Serializable {
     private static final long serialVersionUID = 7707829996758189836L;
     private static final Logger LOG = LoggerFactory.getLogger(KinesisSpout.class);
+    public static final String TOPOLOGY_NAME_MDC_KEY = "component";
 
     private final InitialPositionInStream initialPosition;
 
@@ -112,6 +114,7 @@ public class KinesisSpout implements IRichSpout, Serializable {
         this.context = spoutContext;
         this.collector = spoutCollector;
         this.stateManager = new ZookeeperStateManager(config, shardListGetter, getterBuilder, initialPosition);
+        MDC.put(TOPOLOGY_NAME_MDC_KEY, (String) conf.get(Config.TOPOLOGY_NAME));
         LOG.info(this + " open() called with topoConfig task index " + spoutContext.getThisTaskIndex()
                 + " for processing stream " + config.getStreamName());
         openMetrics(conf);
@@ -143,6 +146,7 @@ public class KinesisSpout implements IRichSpout, Serializable {
 
     @Override
     public void close() {
+        MDC.remove(TOPOLOGY_NAME_MDC_KEY);
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
@@ -254,6 +254,7 @@ public class KinesisSpout implements IRichSpout, Serializable {
         duplicate.setPartitionKey(record.getPartitionKey());
         duplicate.setSequenceNumber(record.getSequenceNumber());
         duplicate.setData(record.getData().duplicate());
+        duplicate.setApproximateArrivalTimestamp(record.getApproximateArrivalTimestamp());
         return duplicate;
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
@@ -15,31 +15,32 @@
 
 package com.amazonaws.services.kinesis.stormspout;
 
-import java.io.Serializable;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import backtype.storm.Config;
+import backtype.storm.metric.api.AssignableMetric;
+import backtype.storm.metric.api.CountMetric;
 import backtype.storm.spout.SpoutOutputCollector;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.IRichSpout;
 import backtype.storm.topology.OutputFieldsDeclarer;
-
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.kinesis.model.Record;
 import com.amazonaws.services.kinesis.stormspout.state.IKinesisSpoutStateManager;
 import com.amazonaws.services.kinesis.stormspout.state.zookeeper.ZookeeperStateManager;
 import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Ints;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Storm spout for Amazon Kinesis. The spout fetches data from Kinesis and emits a tuple for each data record.
- * 
+ *
  * Note: every spout task handles a distinct set of shards.
  */
 public class KinesisSpout implements IRichSpout, Serializable {
@@ -59,12 +60,14 @@ public class KinesisSpout implements IRichSpout, Serializable {
     private transient TopologyContext context;
     private transient IKinesisSpoutStateManager stateManager;
     private transient long lastCommitTime;
+    private transient AssignableMetric millisBehindLastMetric;
+    private transient CountMetric retryCount;
 
     /**
      * Constructs an instance of the spout with just enough data to bootstrap the state from.
      * Construction done here is common to all spout tasks, whereas the IKinesisSpoutStateManager created
      * in activate() is task specific.
-     * 
+     *
      * @param config Spout configuration.
      * @param credentialsProvider Used when making requests to Kinesis.
      * @param clientConfiguration Client configuration used when making calls to Kinesis.
@@ -111,6 +114,31 @@ public class KinesisSpout implements IRichSpout, Serializable {
         this.stateManager = new ZookeeperStateManager(config, shardListGetter, getterBuilder, initialPosition);
         LOG.info(this + " open() called with topoConfig task index " + spoutContext.getThisTaskIndex()
                 + " for processing stream " + config.getStreamName());
+        openMetrics(conf);
+
+    }
+
+    private void openMetrics(final Map<?, ?> conf) {
+        final int bucketSize = getBucketSize(conf.get(Config.TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS), 60);
+        if (config.isTraceMillisBehindLast()) {
+            this.millisBehindLastMetric = this.context.registerMetric("millis_behind_latest_assignable", new AssignableMetric(0), bucketSize);
+        }
+        if (config.isTraceRetryCount()) {
+            this.retryCount = this.context.registerMetric("retry_count", new CountMetric(), bucketSize);
+        }
+
+    }
+
+
+    private int getBucketSize(Object o, int defaultBucketSize) {
+        if (o instanceof Integer) {
+            return ((Integer) o).intValue();
+        } else if (o instanceof String) {
+            Integer b;
+            return ((b = Ints.tryParse((String) o)) == null) ? defaultBucketSize : b;
+        } else {
+            return defaultBucketSize;
+        }
     }
 
     @Override
@@ -162,8 +190,9 @@ public class KinesisSpout implements IRichSpout, Serializable {
             String currentShardId = getter.getAssociatedShard();
             Record rec = null;
             boolean isRetry = false;
-            
+
             if (stateManager.shouldRetry(currentShardId)) {
+                safeMetricIncrement(retryCount);
                 rec = stateManager.recordToRetry(currentShardId);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("ShardId " + currentShardId + ": Re-emitting record with partition key " + rec.getPartitionKey() + ", sequence number "
@@ -171,7 +200,11 @@ public class KinesisSpout implements IRichSpout, Serializable {
                 }
                 isRetry = true;
             } else {
-                final ImmutableList<Record> records = getter.getNext(1).getRecords();
+                final Records rs = getter.getNext(1);
+                if (rs.getMillisBehindLatest() >= 0) {
+                    safeMetricAssign(millisBehindLastMetric, rs.getMillisBehindLatest());
+                }
+                final ImmutableList<Record> records = rs.getRecords();
                 if ((records != null) && (!records.isEmpty())) {
                     rec = records.get(0);
                 }
@@ -212,7 +245,7 @@ public class KinesisSpout implements IRichSpout, Serializable {
     /**
      * Creates a copy of the record so we don't get interference from bolts that execute in the same JVM.
      * We invoke ByteBuffer.duplicate() so the ByteBuffer state is decoupled.
-     * 
+     *
      * @param record Kinesis record
      * @return Copied record.
      */
@@ -262,5 +295,13 @@ public class KinesisSpout implements IRichSpout, Serializable {
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("taskIndex",
                 context.getThisTaskIndex()).toString();
+    }
+
+    private void safeMetricIncrement(CountMetric cm) {
+        if (cm != null) cm.incr();
+    }
+
+    private void safeMetricAssign(AssignableMetric am, Object value) {
+        if (am != null) am.setValue(value);
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpoutConfig.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpoutConfig.java
@@ -15,10 +15,10 @@
 
 package com.amazonaws.services.kinesis.stormspout;
 
-import java.io.Serializable;
-
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
+
+import java.io.Serializable;
 
 /**
  * Kinesis Spout configuration.
@@ -43,6 +43,9 @@ public class KinesisSpoutConfig implements Serializable {
 
     // Gets set by the spout later on.
     private String topologyName = "UNNAMED_TOPOLOGY";
+
+    private boolean traceRetryCount = false;
+    private  boolean traceMillisBehindLast = false;
 
     public KinesisSpoutConfig(final String streamName, final String zookeeperConnectionString) {
         this.streamName = streamName;
@@ -273,5 +276,32 @@ public class KinesisSpoutConfig implements Serializable {
     public KinesisSpoutConfig withEmptyRecordListBackoffMillis(long emptyRecordListBackoffMillis) {
         this.emptyRecordListBackoffMillis = emptyRecordListBackoffMillis;
         return this;
+    }
+
+    /**
+     * @param traceRetryCount enable a metric to trace the number of tuples retried by the spout
+     * @return KinesisSpoutConfig
+     */
+    public KinesisSpoutConfig withTraceRetryCount(boolean traceRetryCount) {
+        this.traceRetryCount = traceRetryCount;
+        return this;
+    }
+
+    /**
+     * @param traceMillisBehindLast enable a metric to trace how far from the tip of the stream is the set of records
+     *                              currently processed by the spout
+     * @return KinesisSpoutConfig
+     */
+    public KinesisSpoutConfig withTraceMillisBehindLast(boolean traceMillisBehindLast) {
+        this.traceMillisBehindLast = traceMillisBehindLast;
+        return this;
+    }
+
+    public boolean isTraceMillisBehindLast() {
+        return traceMillisBehindLast;
+    }
+
+    public boolean isTraceRetryCount() {
+        return traceRetryCount;
     }
 }

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/Records.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/Records.java
@@ -24,16 +24,18 @@ import com.google.common.collect.ImmutableList;
  */
 class Records {
     private final ImmutableList<Record> records;
+    private final long millisBehindLatest;
     private final boolean endOfShard;
 
     /**
      * Constructor.
-     * 
+     *
      * @param records Kinesis records
      * @param endOfShard Did we reach the end of the shard?
      */
-    Records(final ImmutableList<Record> records, final boolean endOfShard) {
+    Records(final ImmutableList<Record> records, final long millisBehindLatest, final boolean endOfShard) {
         this.records = records;
+        this.millisBehindLatest = millisBehindLatest;
         this.endOfShard = endOfShard;
     }
 
@@ -49,7 +51,7 @@ class Records {
      * @return a new empty set of records for an open or closed shard.
      */
     static Records empty(final boolean closed) {
-        return new Records(ImmutableList.<Record> of(), closed);
+        return new Records(ImmutableList.<Record> of(), -1l, closed);
     }
 
     /**
@@ -68,10 +70,18 @@ class Records {
 
     /**
      * Does the Records instance contain records?
-     * 
+     *
      * @return true if getRecords() has records.
      */
     boolean isEmpty() {
         return records.isEmpty();
+    }
+
+    /**
+     * @return the number of milliseconds the set of records is from the tip of the stream
+     *         Returns -1 if the set is empty
+     */
+    public long getMillisBehindLatest() {
+        return millisBehindLatest;
     }
 }


### PR DESCRIPTION
This PR is to:
- Add millis behind latest and retry count metrics in KinesisSpout
- Support ApproximateArrivalTimestamp on Record
- Update guava version to 18.0
- Depend only on aws-java-sdk-kinesis
- Register MDC key for TOPOLOGY_NAME
