### PR TITLE
updating to current version of Storm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
+target/
+AwsCredentials.properties
 .idea
 *.iml
 *.project
 *.class
-target

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-target/
-AwsCredentials.properties
+.idea
+*.iml
+*.project
+*.class
+target

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>kinesis-storm-spout</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Storm Spout for Java</name>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <description> The Amazon Kinesis Storm Spout helps Java developers integrate Amazon Kinesis with Storm.</description>
     <url>https://aws.amazon.com/kinesis</url>
 
@@ -24,8 +24,8 @@
 
 
     <properties>
-        <aws-java-sdk.version>1.7.13</aws-java-sdk.version>
-        <storm.version>0.9.2-incubating</storm.version>
+        <aws-java-sdk.version>1.11.90</aws-java-sdk.version>
+        <storm.version>1.0.2</storm.version>
         <curator-framework.version>1.1.3</curator-framework.version>
         <guava.version>13.0</guava.version>
         <commons-lang3.version>3.0</commons-lang3.version>

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/DefaultKinesisRecordScheme.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/DefaultKinesisRecordScheme.java
@@ -18,7 +18,7 @@ package com.amazonaws.services.kinesis.stormspout;
 import java.util.ArrayList;
 import java.util.List;
 
-import backtype.storm.tuple.Fields;
+import org.apache.storm.tuple.Fields;
 
 import com.amazonaws.services.kinesis.model.Record;
 

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/IKinesisRecordScheme.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/IKinesisRecordScheme.java
@@ -17,7 +17,7 @@ package com.amazonaws.services.kinesis.stormspout;
 
 import java.util.List;
 
-import backtype.storm.tuple.Fields;
+import org.apache.storm.tuple.Fields;
 
 import com.amazonaws.services.kinesis.model.Record;
 

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisHelper.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisHelper.java
@@ -69,7 +69,7 @@ class KinesisHelper implements IShardListGetter {
         this.streamName = streamName;
         this.serializedKinesisCredsProvider = SerializationHelper.kryoSerializeObject(kinesisCredsProvider);
         this.serializedkinesisClientConfig = SerializationHelper.kryoSerializeObject(kinesisClientConfig);
-        this.serializedRegion = SerializationHelper.kryoSerializeObject(region);
+        this.serializedRegion = SerializationHelper.kryoSerializeObject(region.getName());
 
         this.kinesisCredsProvider = null;
         this.kinesisClientConfig = null;
@@ -155,7 +155,7 @@ class KinesisHelper implements IShardListGetter {
 
     private Region getRegion() {
         if (region == null) {
-            region = (Region) SerializationHelper.kryoDeserializeObject(serializedRegion);
+            region = Region.getRegion(Regions.fromName((String) SerializationHelper.kryoDeserializeObject(serializedRegion)));
         }
         return region;
     }

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
@@ -24,11 +24,11 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import backtype.storm.Config;
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.IRichSpout;
-import backtype.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.Config;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.IRichSpout;
+import org.apache.storm.topology.OutputFieldsDeclarer;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;

--- a/src/main/samples/SampleBolt.java
+++ b/src/main/samples/SampleBolt.java
@@ -23,11 +23,11 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.BasicOutputCollector;
-import backtype.storm.topology.OutputFieldsDeclarer;
-import backtype.storm.topology.base.BaseBasicBolt;
-import backtype.storm.tuple.Tuple;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.BasicOutputCollector;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseBasicBolt;
+import org.apache.storm.tuple.Tuple;
 
 import com.amazonaws.services.kinesis.model.Record;
 

--- a/src/main/samples/SampleKinesisRecordScheme.java
+++ b/src/main/samples/SampleKinesisRecordScheme.java
@@ -16,7 +16,7 @@
 import java.util.ArrayList;
 import java.util.List;
 
-import backtype.storm.tuple.Fields;
+import org.apache.storm.tuple.Fields;
 
 import com.amazonaws.services.kinesis.model.Record;
 import com.amazonaws.services.kinesis.stormspout.IKinesisRecordScheme;

--- a/src/main/samples/SampleTopology.java
+++ b/src/main/samples/SampleTopology.java
@@ -22,13 +22,13 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import backtype.storm.Config;
-import backtype.storm.LocalCluster;
-import backtype.storm.StormSubmitter;
-import backtype.storm.generated.AlreadyAliveException;
-import backtype.storm.generated.InvalidTopologyException;
-import backtype.storm.topology.TopologyBuilder;
-import backtype.storm.tuple.Fields;
+import org.apache.storm.Config;
+import org.apache.storm.LocalCluster;
+import org.apache.storm.StormSubmitter;
+import org.apache.storm.generated.AlreadyAliveException;
+import org.apache.storm.generated.InvalidTopologyException;
+import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.tuple.Fields;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.regions.Regions;


### PR DESCRIPTION
The version of storm used in the 1.1.1 release is quite old and not compatible with the current 1.0.2 release of Storm. Updating the package names to make this usable on newer builds of Storm