### PR TITLE
support 1.0.x storm builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
+target/
+AwsCredentials.properties
 .idea
 *.iml
 *.project
 *.class
-target

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-target/
-AwsCredentials.properties
+.idea
+*.iml
+*.project
+*.class
+target

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
             <version>${aws-java-sdk.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${aws-java-sdk.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
 
     <properties>
-        <aws-java-sdk.version>1.11.90</aws-java-sdk.version>
+        <aws-java-sdk.version>1.11.119</aws-java-sdk.version>
         <storm.version>1.1.0</storm.version>
         <curator-framework.version>1.1.3</curator-framework.version>
         <guava.version>13.0</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <aws-java-sdk.version>1.11.90</aws-java-sdk.version>
-        <storm.version>1.0.3</storm.version>
+        <storm.version>1.1.0</storm.version>
         <curator-framework.version>1.1.3</curator-framework.version>
         <guava.version>13.0</guava.version>
         <commons-lang3.version>3.0</commons-lang3.version>
@@ -110,6 +110,20 @@
       </pluginManagement>
 
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.4</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>kinesis-storm-spout</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Storm Spout for Java</name>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <description> The Amazon Kinesis Storm Spout helps Java developers integrate Amazon Kinesis with Storm.</description>
     <url>https://aws.amazon.com/kinesis</url>
 
@@ -24,8 +24,8 @@
 
 
     <properties>
-        <aws-java-sdk.version>1.7.13</aws-java-sdk.version>
-        <storm.version>0.9.2-incubating</storm.version>
+        <aws-java-sdk.version>1.11.90</aws-java-sdk.version>
+        <storm.version>1.0.2</storm.version>
         <curator-framework.version>1.1.3</curator-framework.version>
         <guava.version>13.0</guava.version>
         <commons-lang3.version>3.0</commons-lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <aws-java-sdk.version>1.11.90</aws-java-sdk.version>
-        <storm.version>1.0.2</storm.version>
+        <storm.version>1.0.3</storm.version>
         <curator-framework.version>1.1.3</curator-framework.version>
         <guava.version>13.0</guava.version>
         <commons-lang3.version>3.0</commons-lang3.version>

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/DefaultKinesisRecordScheme.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/DefaultKinesisRecordScheme.java
@@ -18,7 +18,7 @@ package com.amazonaws.services.kinesis.stormspout;
 import java.util.ArrayList;
 import java.util.List;
 
-import backtype.storm.tuple.Fields;
+import org.apache.storm.tuple.Fields;
 
 import com.amazonaws.services.kinesis.model.Record;
 

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/IKinesisRecordScheme.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/IKinesisRecordScheme.java
@@ -17,7 +17,7 @@ package com.amazonaws.services.kinesis.stormspout;
 
 import java.util.List;
 
-import backtype.storm.tuple.Fields;
+import org.apache.storm.tuple.Fields;
 
 import com.amazonaws.services.kinesis.model.Record;
 

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisHelper.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisHelper.java
@@ -69,7 +69,7 @@ class KinesisHelper implements IShardListGetter {
         this.streamName = streamName;
         this.serializedKinesisCredsProvider = SerializationHelper.kryoSerializeObject(kinesisCredsProvider);
         this.serializedkinesisClientConfig = SerializationHelper.kryoSerializeObject(kinesisClientConfig);
-        this.serializedRegion = SerializationHelper.kryoSerializeObject(region);
+        this.serializedRegion = SerializationHelper.kryoSerializeObject(region.getName());
 
         this.kinesisCredsProvider = null;
         this.kinesisClientConfig = null;
@@ -155,7 +155,7 @@ class KinesisHelper implements IShardListGetter {
 
     private Region getRegion() {
         if (region == null) {
-            region = (Region) SerializationHelper.kryoDeserializeObject(serializedRegion);
+            region = Region.getRegion(Regions.fromName((String) SerializationHelper.kryoDeserializeObject(serializedRegion)));
         }
         return region;
     }

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/KinesisSpout.java
@@ -24,11 +24,11 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import backtype.storm.Config;
-import backtype.storm.spout.SpoutOutputCollector;
-import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.IRichSpout;
-import backtype.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.Config;
+import org.apache.storm.spout.SpoutOutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.IRichSpout;
+import org.apache.storm.topology.OutputFieldsDeclarer;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/LazySTSAssumeRoleSessionCredentialsProvider.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/LazySTSAssumeRoleSessionCredentialsProvider.java
@@ -1,0 +1,43 @@
+package com.amazonaws.services.kinesis.stormspout;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+
+public class LazySTSAssumeRoleSessionCredentialsProvider implements AWSCredentialsProvider {
+  private final AWSCredentialsProvider baseProvider;
+  private final String roleArn;
+  private final String roleSessionName;
+
+  private STSAssumeRoleSessionCredentialsProvider provider = null;
+
+  public LazySTSAssumeRoleSessionCredentialsProvider(AWSCredentialsProvider baseProvider, String roleArn, String roleSessionName) {
+    this.baseProvider = baseProvider;
+    this.roleArn = roleArn;
+    this.roleSessionName = roleSessionName;
+  }
+
+  private synchronized AWSCredentialsProvider getProvider() {
+    if (provider == null) {
+      provider = new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
+              .withStsClient(AWSSecurityTokenServiceClientBuilder.standard()
+                      .withCredentials(new DefaultAWSCredentialsProviderChain())
+                      .build())
+              .build();
+    }
+
+    return provider;
+  }
+
+  @Override
+  public AWSCredentials getCredentials() {
+    return getProvider().getCredentials();
+  }
+
+  @Override
+  public void refresh() {
+    getProvider().refresh();
+  }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/RecordSerializer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/RecordSerializer.java
@@ -1,0 +1,44 @@
+package com.amazonaws.services.kinesis.stormspout;
+
+import com.amazonaws.services.kinesis.model.Record;
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+
+import java.nio.ByteBuffer;
+import java.util.Date;
+
+public class RecordSerializer extends Serializer<Record> {
+  @Override
+  public void write(Kryo kryo, Output output, Record record) {
+    output.writeString(record.getPartitionKey());
+    output.writeString(record.getSequenceNumber());
+    output.writeBoolean(record.getApproximateArrivalTimestamp() != null);
+    if (record.getApproximateArrivalTimestamp() != null) {
+      output.writeLong(record.getApproximateArrivalTimestamp().getTime());
+    }
+
+    byte[] bytes = SerializationHelper.copyData(record.getData());
+    output.writeInt(bytes.length);
+    output.writeBytes(bytes);
+  }
+
+  @Override
+  public Record read(Kryo kryo, Input input, Class<Record> aClass) {
+    Record record = new Record();
+
+    record.setPartitionKey(input.readString());
+    record.setSequenceNumber(input.readString());
+
+    if (input.readBoolean()) {
+      record.setApproximateArrivalTimestamp(new Date(input.readLong()));
+    }
+
+    int length = input.readInt();
+    byte[] bytes = input.readBytes(length);
+    record.setData(ByteBuffer.wrap(bytes));
+
+    return record;
+  }
+}

--- a/src/main/java/com/amazonaws/services/kinesis/stormspout/utils/InfiniteConstantBackoffRetry.java
+++ b/src/main/java/com/amazonaws/services/kinesis/stormspout/utils/InfiniteConstantBackoffRetry.java
@@ -62,8 +62,8 @@ public class InfiniteConstantBackoffRetry<T> implements Callable<T> {
                 return f.call();
             } catch (Exception e) {
                 if (retryOn.isAssignableFrom(e.getClass())) {
-                    LOG.debug("Caught exception of type " + retryOn.getName() + ", backing off for " + backoffMillis
-                            + " ms.");
+                    LOG.debug("Caught exception of type " + retryOn.getName() + ", backing off for " + backoffMillis + " ms.");
+                    LOG.trace("Caught exception", e);
                     Thread.sleep(backoffMillis);
                 } else {
                     throw e;

--- a/src/main/samples/SampleBolt.java
+++ b/src/main/samples/SampleBolt.java
@@ -23,11 +23,11 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.BasicOutputCollector;
-import backtype.storm.topology.OutputFieldsDeclarer;
-import backtype.storm.topology.base.BaseBasicBolt;
-import backtype.storm.tuple.Tuple;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.BasicOutputCollector;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseBasicBolt;
+import org.apache.storm.tuple.Tuple;
 
 import com.amazonaws.services.kinesis.model.Record;
 

--- a/src/main/samples/SampleKinesisRecordScheme.java
+++ b/src/main/samples/SampleKinesisRecordScheme.java
@@ -16,7 +16,7 @@
 import java.util.ArrayList;
 import java.util.List;
 
-import backtype.storm.tuple.Fields;
+import org.apache.storm.tuple.Fields;
 
 import com.amazonaws.services.kinesis.model.Record;
 import com.amazonaws.services.kinesis.stormspout.IKinesisRecordScheme;

--- a/src/main/samples/SampleTopology.java
+++ b/src/main/samples/SampleTopology.java
@@ -22,13 +22,13 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import backtype.storm.Config;
-import backtype.storm.LocalCluster;
-import backtype.storm.StormSubmitter;
-import backtype.storm.generated.AlreadyAliveException;
-import backtype.storm.generated.InvalidTopologyException;
-import backtype.storm.topology.TopologyBuilder;
-import backtype.storm.tuple.Fields;
+import org.apache.storm.Config;
+import org.apache.storm.LocalCluster;
+import org.apache.storm.StormSubmitter;
+import org.apache.storm.generated.AlreadyAliveException;
+import org.apache.storm.generated.InvalidTopologyException;
+import org.apache.storm.topology.TopologyBuilder;
+import org.apache.storm.tuple.Fields;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.regions.Regions;


### PR DESCRIPTION
Storm changed its package names as part of the 1.0.x release, so the spout needed to be updated in order to be used with new clusters.  This updates to allow connecting to 1.0.3 clusters (should work for other 1.0.x clusters as well), and fixes a few serialization issues so that bolts will be able to AssumeRole if required.

You can do whatever you want with these changes, apply whatever licence is necessary.